### PR TITLE
[docker-compose] restart controller as a workaround for finding a healthy invoker

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -45,7 +45,7 @@ docker:
 	    ./gradlew distdocker -x :core:swift3Action:distDocker -x :core:swiftAction:distDocker
 
 .PHONY: run
-run: check-required-ports setup start-docker-compose init-couchdb init-whisk-cli
+run: check-required-ports setup start-docker-compose init-couchdb restart-controller init-whisk-cli
 
 .PHONY: check-required-ports
 check-required-ports:
@@ -65,6 +65,12 @@ setup:
 
 .PHONY: restart
 restart: stop rm start-docker-compose
+
+.PHONY: restart-controller
+restart-controller:
+	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk restart controller 2>&1 > ~/tmp/openwhisk/docker-compose.log &
+	echo "waiting until the controller recognizes a healthy invoker ... "
+	until [ "$$(curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep up)" == '  "invoker0": "up"' ]; do printf '.'; sleep 5; done
 
 .PHONY: start-docker-compose
 start-docker-compose:
@@ -148,4 +154,3 @@ hello-world-perf-test: create-hello-world-function
 	            http://controller:8888/api/v1/namespaces/guest/actions/hello-perf?blocking=true
 
 	$(WSK_CLI) -i action delete hello-perf
-	rm hello.js

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -154,3 +154,4 @@ hello-world-perf-test: create-hello-world-function
 	            http://controller:8888/api/v1/namespaces/guest/actions/hello-perf?blocking=true
 
 	$(WSK_CLI) -i action delete hello-perf
+	rm hello.js

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -70,7 +70,7 @@ restart: stop rm start-docker-compose
 restart-controller:
 	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk restart controller 2>&1 > ~/tmp/openwhisk/docker-compose.log &
 	echo "waiting until the controller recognizes a healthy invoker ... "
-	until [ "$$(curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep up)" == '  "invoker0": "up"' ]; do printf '.'; sleep 5; done
+	until (curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep "up"); do printf '.'; sleep 5; done
 
 .PHONY: start-docker-compose
 start-docker-compose:


### PR DESCRIPTION
This PR provides a temporary work-around for https://github.com/apache/incubator-openwhisk/issues/2263 

The controller restarts after DB is initialized in order to create the `whisk.system/invokerHealthTestAction` and then waits for the invoker to become healthy.