### PR TITLE
Fix scancode errors in README (EOL) and node-local test.js.

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -8,7 +8,7 @@ An easy way to try OpenWhisk locally is to use Docker Compose.
 
 The following are required to build and deploy OpenWhisk with Docker Compose:
 
-- [Docker 1.12+](https://www.docker.com/products/docker) 
+- [Docker 1.12+](https://www.docker.com/products/docker)
 - [Docker Compose 1.6+](https://docs.docker.com/compose/install/)
 - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
@@ -36,9 +36,9 @@ At the end of the execution it prints the output of the function:
 }
 ```
 
-If `PROJECT_HOME` variable is set ( i.e. `PROJECT_HOME=/path/to/openwhisk make quick-start`) 
-then the command skips downloading the `master` branch and uses instead the source code found in the `PROJECT_HOME` folder. 
-This is useful for working with a local clone, making changes to the code, and run it with `docker-compose`.   
+If `PROJECT_HOME` variable is set ( i.e. `PROJECT_HOME=/path/to/openwhisk make quick-start`)
+then the command skips downloading the `master` branch and uses instead the source code found in the `PROJECT_HOME` folder.
+This is useful for working with a local clone, making changes to the code, and run it with `docker-compose`.
 
 # Build
 
@@ -67,7 +67,7 @@ make stop
 ```
 
 To remove the stopped containers, clean the database files and the temporary files use:
- 
+
  ```bash
  make destroy
  ```
@@ -80,19 +80,19 @@ Once OpenWhisk is up and running you can execute a `hello-world` function:
 make hello-world
 ```
 
-This command creates a new JS action, it invokes it, and then it deletes it. 
+This command creates a new JS action, it invokes it, and then it deletes it.
   The javascript action is:
 ```javascript
 function main(params) {
     var name = params.name || "World";
     return {payload: "Hello, " + name + "!"};
 }
-```  
+```
 The result of the invokation should be printed on the terminal:
 ```
 {
     "payload": "Hello, World!"
-} 
+}
 ```
 
 ## Logs
@@ -109,4 +109,4 @@ To start `docker-compose` with custom images used for running actions use the fo
 - `DOCKER_REGISTRY` - specify a custom docker registry. I.e ```DOCKER_REGISTRY=registry.example.com make quick-start```
 - `DOCKER_IMAGE_PREFIX` - specify a custom image prefix. I.e. ```DOCKER_IMAGE_PREFIX=my-prefix make quick-start```
 
-These 2 variable allow you to execute a JS action using the container `registry.example.com/my-prefix/nodejs6action` .
+These 2 variable allow you to execute a JS action using the container `registry.example.com/my-prefix/nodejs6action`.

--- a/node-local/test.js
+++ b/node-local/test.js
@@ -1,3 +1,6 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more contributor
+// license agreements; and to You under the Apache License, Version 2.0.
+
 process.stdin.setEncoding('utf8');
 
 var args = process.argv;
@@ -32,17 +35,17 @@ if (process.stdin.isTTY) {
 } else {
   //if stdin, read input and parse as JSON
   var input = "";
-  
+
   process.stdin.on('readable', () => {
     var chunk = process.stdin.read();
     if (chunk !== null) {
       input += chunk;
     }
   });
-  
+
   process.stdin.on('end', () => {
     const params = JSON.parse(input);
-    
+
     run(action, params, json);
   });
 }
@@ -75,12 +78,12 @@ function run(action, params, outputJSON) {
     help();
     process.exit(1);
   }
-  
+
   const imports = require(action);
 
   //support a non-exported main function as a fallback
   const mainfunct = imports.main ? imports.main : fallback(action);
-  
+
   let result = mainfunct(params);
   if (result.then) {
     Promise.resolve(result)


### PR DESCRIPTION
We are turning global scancode and remove the "exclusion" for the devtools repo.  the 2 files on this PR showed scancode errors when run manually that need to be corrected before we alter the global configuration file.