### PR TITLE
fixing the issue with container reuse for consecutive invocations

### DIFF
--- a/docker-compose/.travis/build.sh
+++ b/docker-compose/.travis/build.sh
@@ -4,4 +4,4 @@ SCRIPTDIR=$(cd $(dirname "$0") && pwd)
 ROOTDIR="$SCRIPTDIR/../"
 
 cd $ROOTDIR
-PATH=$PATH:/usr/local/bin/ make quick-start stop
+PATH=$PATH:/usr/local/bin/ VERBOSE=true make quick-start stop

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -73,7 +73,19 @@ restart: stop rm start-docker-compose
 
 .PHONY: restart-controller
 restart-controller:
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk restart controller 2>&1 > ~/tmp/openwhisk/docker-compose.log &
+	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk stop controller
+	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk rm controller
+	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk up controller 2>&1 >> ~/tmp/openwhisk/docker-compose.log &
+	echo "waiting for the controller to see the invoker is 'up' ... "
+	until (curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep "up"); do printf '.'; sleep 5; done
+
+.PHONY: restart-invoker
+restart-invoker:
+	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk stop invoker
+	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk rm invoker
+	echo "waiting for the invoker to be marked 'down' ... "
+	until (curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep "down"); do printf '.'; sleep 5; done
+	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk up invoker 2>&1 >> ~/tmp/openwhisk/docker-compose.log &
 	echo "waiting for the invoker to be marked Healthy ... "
 	until (curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep "up"); do printf '.'; sleep 5; done
 

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -6,9 +6,17 @@ WSK_CLI ?= $(PROJECT_HOME)/bin/wsk
 
 OPEN_WHISK_DB_PREFIX ?= local_
 
+DOCKER_KERNEL ?= $(shell docker version --format "{{.Server.KernelVersion}}")
+RUNC_BINARY   ?= $(shell if [[ $(DOCKER_KERNEL) == *-moby || $(DOCKER_KERNEL) ==  *-boot2docker ]]; then (docker run --rm --privileged --pid=host debian nsenter -t 1 -m -u -n -i sh -c "which runc || which docker-runc"); else (which runc || which docker-runc); fi)
+DOCKER_BINARY ?= $(shell if [[ $(DOCKER_KERNEL) == *-moby || $(DOCKER_KERNEL) ==  *-boot2docker ]]; then (docker run --rm --privileged --pid=host debian nsenter -t 1 -m -u -n -i sh -c "which docker"); else (which docker); fi)
+
 ifndef VERBOSE
 .SILENT:
 endif
+
+.PHONY: ddd
+ddd:
+	$(shell cat ~/tmp/openwhisk/local.env) && echo $${DOCKER_IMAGE_PREFIX}
 
 # Quick-Start is a simple way to get started with OpenWhisk locally
 #   1. at start it builds the project and the docker containers
@@ -67,39 +75,45 @@ setup:
 	cd $(PROJECT_HOME)/ansible/roles/nginx/files/ && ./genssl.sh $(DOCKER_HOST_IP) server
 	cp $(PROJECT_HOME)/ansible/roles/nginx/files/*.pem ~/tmp/openwhisk/apigateway/ssl
 	cp -r ./apigateway/* ~/tmp/openwhisk/apigateway/
+	> ~/tmp/openwhisk/local.env
+	printf "DOCKER_BINARY=$(DOCKER_BINARY)\n" >> ~/tmp/openwhisk/local.env
+	printf "RUNC_BINARY=$(RUNC_BINARY)\n" >> ~/tmp/openwhisk/local.env
+	printf "DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP)\n" >> ~/tmp/openwhisk/local.env
+	printf "DOCKER_REGISTRY=$(DOCKER_REGISTRY)\n" >> ~/tmp/openwhisk/local.env
+	printf "DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX)\n" >> ~/tmp/openwhisk/local.env
 
 .PHONY: restart
 restart: stop rm start-docker-compose
 
 .PHONY: restart-controller
 restart-controller:
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk stop controller
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk rm controller
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk up controller 2>&1 >> ~/tmp/openwhisk/docker-compose.log &
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk stop controller
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk rm controller
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk up controller 2>&1 >> ~/tmp/openwhisk/docker-compose.log &
 	echo "waiting for the controller to see the invoker is 'up' ... "
 	until (curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep "up"); do printf '.'; sleep 5; done
 
 .PHONY: restart-invoker
 restart-invoker:
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk stop invoker
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk rm invoker
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk stop invoker
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk rm invoker
 	echo "waiting for the invoker to be marked 'down' ... "
 	until (curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep "down"); do printf '.'; sleep 5; done
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk up invoker 2>&1 >> ~/tmp/openwhisk/docker-compose.log &
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk up invoker 2>&1 >> ~/tmp/openwhisk/docker-compose.log &
 	echo "waiting for the invoker to be marked Healthy ... "
 	until (curl --silent http://$(DOCKER_HOST_IP):8888/invokers | grep "up"); do printf '.'; sleep 5; done
 
 .PHONY: start-docker-compose
 start-docker-compose:
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk up 2>&1 > ~/tmp/openwhisk/docker-compose.log &
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk up 2>&1 > ~/tmp/openwhisk/docker-compose.log &
 
 .PHONY: stop
 stop:
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk stop
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk stop
 
 .PHONY: rm
 rm:
-	DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP) DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX) docker-compose --project-name openwhisk rm
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk rm
 
 .PHONY: init-couchdb
 init-couchdb:

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -161,7 +161,7 @@ hello-world: create-hello-world-function
 	echo "$$(tput setaf 4)invoking the function ...$$(tput sgr0)"
 	res=`$(WSK_CLI) -i action invoke hello --blocking --result` \
 	    && echo "invokation result:" $$res \
-	    && (echo $$res | grep "Hello, World") || ($(WSK_CLI) -i action delete hello && exit 1)
+	    && (echo $$res | grep "Hello, World") || ($(WSK_CLI) -i action delete hello && tail -n 200 ~/tmp/openwhisk/invoker/logs/invoker-local_logs.log ~/tmp/openwhisk/controller/logs/controller-local_logs.log && exit 1)
 
 	echo "$$(tput setaf 1)deleting the function ...$$(tput sgr0)"
 	$(WSK_CLI) -i action delete hello

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -43,16 +43,32 @@ If `PROJECT_HOME` variable is set ( i.e. `PROJECT_HOME=/path/to/openwhisk make q
 then the command skips downloading the `master` branch and uses instead the source code found in the `PROJECT_HOME` folder.
 This is useful for working with a local clone, making changes to the code, and run it with `docker-compose`.
 
+## Updating OpenWhisk Invoker or Controller
+
+To update the OpenWhisk Invoker or Controller without restarting everything, run:
+
+```bash
+make restart-invoker
+```
+This command destroys the running Invoker instance, waits for the controller to figure out the invoker is `down`, then it starts a new Invoker, also waiting until it's marked as `up`.
+
+To do the same with the controller run:
+
+```bash
+make restart-controller
+```
+
+
 ## Troubleshooting
 
 * ```error: Authenticated user does not have namespace 'guest'; set command failed: Get https://localhost:443/api/v1/namespaces: dial tcp [::1]:443: getsockopt: connection refused```
 
   Make sure nothing runs on the above listed ports. Port 80 might be commonly in use by a local httpd for example. On a Mac, use `sudo lsof -i -P` to find out what process runs on a port. You can turn off Internet Sharing under System Settings > Sharing, or try `sudo /usr/sbin/apachectl stop` to stop httpd.
-  
+
 * ```error: Unable to invoke action 'hello': There was an internal server error. (code 5)```
 
   Look at the logs in `~/tmp/openwhisk` especially `~/tmp/openwhisk/controller/logs/controller-local_logs.log` that might give more information. This can be an indication that the docker environment doesn't work properly (and on Mac you might need to switch to use [Docker for Mac](https://www.docker.com/docker-mac).
-  
+
 * Check the [issue tracker](https://github.com/apache/incubator-openwhisk-devtools/issues) for more.
 
 # Build

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -8,18 +8,22 @@ An easy way to try OpenWhisk locally is to use Docker Compose.
 
 The following are required to build and deploy OpenWhisk with Docker Compose:
 
-- [Docker 1.12+](https://www.docker.com/products/docker)
-- [Docker Compose 1.6+](https://docs.docker.com/compose/install/)
+- Mac OSX:
+    - [Docker for Mac](https://www.docker.com/docker-mac) - only this currently works on Mac OSX
+      + Install via homebrew: `brew cask install docker`
+- Other Systems:
+    - [Docker 1.12+](https://www.docker.com/products/docker)
+    - [Docker Compose 1.6+](https://docs.docker.com/compose/install/)
 - [Java 8](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
 
-Available Ports:
+These ports must be available:
 
-- `5984` for CouchDB
-- `2181` for Zookeeper
-- `9092` for Kafka
-- `8888` for OpenWhisk's Controller
-- `8085` for OpenWhisk's Invoker
 - `80` and `443` for the API Gateway
+- `2181` for Zookeeper
+- `5984` for CouchDB
+- `8085` for OpenWhisk's Invoker
+- `8888` for OpenWhisk's Controller
+- `9092` for Kafka
 
 # Quick Start
 
@@ -38,6 +42,18 @@ At the end of the execution it prints the output of the function:
 If `PROJECT_HOME` variable is set ( i.e. `PROJECT_HOME=/path/to/openwhisk make quick-start`)
 then the command skips downloading the `master` branch and uses instead the source code found in the `PROJECT_HOME` folder.
 This is useful for working with a local clone, making changes to the code, and run it with `docker-compose`.
+
+## Troubleshooting
+
+* ```error: Authenticated user does not have namespace 'guest'; set command failed: Get https://localhost:443/api/v1/namespaces: dial tcp [::1]:443: getsockopt: connection refused```
+
+  Make sure nothing runs on the above listed ports. Port 80 might be commonly in use by a local httpd for example. On a Mac, use `sudo lsof -i -P` to find out what process runs on a port. You can turn off Internet Sharing under System Settings > Sharing, or try `sudo /usr/sbin/apachectl stop` to stop httpd.
+  
+* ```error: Unable to invoke action 'hello': There was an internal server error. (code 5)```
+
+  Look at the logs in `~/tmp/openwhisk` especially `~/tmp/openwhisk/controller/logs/controller-local_logs.log` that might give more information. This can be an indication that the docker environment doesn't work properly (and on Mac you might need to switch to use [Docker for Mac](https://www.docker.com/docker-mac).
+  
+* Check the [issue tracker](https://github.com/apache/incubator-openwhisk-devtools/issues) for more.
 
 # Build
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '3'
 services:
   db:
     image: couchdb:1.6
@@ -66,6 +66,9 @@ services:
   invoker:
     image: openwhisk/invoker:latest
     command: /bin/sh -c "/invoker/bin/invoker 0 >> /logs/invoker-local_logs.log 2>&1"
+    privileged: true
+    pid: "host"
+    userns_mode: "host"
     links:
       - db:db.docker
       - kafka:kafka.docker
@@ -97,11 +100,15 @@ services:
 
       INVOKER_CONTAINER_NETWORK: openwhisk_default
 
-      WHISK_API_HOST_NAME: https://${DOCKER_COMPOSE_HOST}
+      WHISK_API_HOST_NAME: ${DOCKER_COMPOSE_HOST}
     volumes:
       - ~/tmp/openwhisk/invoker/logs:/logs
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/containers:/containers
+      - /usr/bin/docker:/usr/bin/docker
+      - /run/runc:/run/runc
+      - /usr/bin/runc:/usr/bin/docker-runc
+      - /sys/fs/cgroup/freezer:/sys/fs/cgroup/freezer
     ports:
       - "8085:8085"
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -104,7 +104,6 @@ services:
       - ~/tmp/openwhisk/invoker/logs:/logs
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/containers:/containers
-      - ${DOCKER_BINARY}:/usr/bin/docker
       - ${RUNC_BINARY}:/usr/bin/docker-runc
       - /run/runc:/run/runc
       - /sys/fs/cgroup:/sys/fs/cgroup

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -40,7 +40,8 @@ services:
       - db
       - kafka
     env_file:
-      - ./docker-whisk-controller.env
+      - ./docker-whisk-controller.env   # env vars shared
+      - ~/tmp/openwhisk/local.env       # generated during make setup
     environment:
       COMPONENT_NAME: controller
       PORT: 8888
@@ -77,6 +78,7 @@ services:
       - kafka
     env_file:
       - ./docker-whisk-controller.env # env vars shared
+      - ~/tmp/openwhisk/local.env     # generated during make setup
     environment:
       COMPONENT_NAME: invoker
       SERVICE_NAME: invoker0
@@ -95,9 +97,6 @@ services:
       EDGE_HOST: ${DOCKER_COMPOSE_HOST}
       EDGE_HOST_APIPORT: 443
 
-      DOCKER_REGISTRY: ${DOCKER_REGISTRY}
-      DOCKER_IMAGE_PREFIX: ${DOCKER_IMAGE_PREFIX}
-
       INVOKER_CONTAINER_NETWORK: openwhisk_default
 
       WHISK_API_HOST_NAME: ${DOCKER_COMPOSE_HOST}
@@ -105,10 +104,10 @@ services:
       - ~/tmp/openwhisk/invoker/logs:/logs
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/lib/docker/containers:/containers
-      - /usr/bin/docker:/usr/bin/docker
+      - ${DOCKER_BINARY}:/usr/bin/docker
+      - ${RUNC_BINARY}:/usr/bin/docker-runc
       - /run/runc:/run/runc
-      - /usr/bin/runc:/usr/bin/docker-runc
-      - /sys/fs/cgroup/freezer:/sys/fs/cgroup/freezer
+      - /sys/fs/cgroup:/sys/fs/cgroup
     ports:
       - "8085:8085"
 


### PR DESCRIPTION
Fixes https://github.com/apache/incubator-openwhisk/issues/2788 with Docker for Mac and docker-compose.

Inspired from https://github.com/apache/incubator-openwhisk/pull/2793

Changelist:
- [x] Mount `runc` binaries from the host machine
- [x] Upgrade to `v3` docker-compose file format 
- [x] Invoker image is staretd with `privileged`, `pid:host` and `userns_mode:host` 


