### PR TITLE
calling openwhisk from action fails because api host is set to "localhost" #58

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -1,4 +1,4 @@
-DOCKER_HOST_IP ?= $(shell echo ${DOCKER_HOST} | grep -o "[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}" || echo localhost)
+DOCKER_HOST_IP ?= $(shell echo ${DOCKER_HOST} | grep -o "[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}" || hostname)
 DOCKER_REGISTRY ?= ""
 DOCKER_IMAGE_PREFIX ?= openwhisk
 PROJECT_HOME ?= ./openwhisk-master

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -97,7 +97,7 @@ services:
 
       INVOKER_CONTAINER_NETWORK: openwhisk_default
 
-      WHISK_API_HOST_NAME: https://${DOCKER_COMPOSE_HOST}
+      WHISK_API_HOST_NAME: ${DOCKER_COMPOSE_HOST}
     volumes:
       - ~/tmp/openwhisk/invoker/logs:/logs
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
For #58:
* using `hostname` to detect the host name of the Docker host instead of falling back to `localhost`
* removing unnecessary `https://` prefix on `WHISK_API_HOST_NAME`