### PR TITLE
calling openwhisk from action fails because api host is set to "localhost" #58

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -1,4 +1,6 @@
-DOCKER_HOST_IP ?= $(shell echo ${DOCKER_HOST} | grep -o "[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}" || echo localhost)
+# detect local ip of host as this is needed within containers to find the openwhisk API container
+LOCAL_IP ?= $(shell ifconfig | grep "inet " | grep -v 127.0.0.1 | cut -d\  -f2 | head -1)
+DOCKER_HOST_IP ?= $(shell echo ${DOCKER_HOST} | grep -o "[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}" || echo ${LOCAL_IP})
 DOCKER_REGISTRY ?= ""
 DOCKER_IMAGE_PREFIX ?= openwhisk
 PROJECT_HOME ?= ./openwhisk-master
@@ -54,7 +56,10 @@ build-cli:
 		./gradlew :tools:cli:distDocker
 
 .PHONY: run
-run: check-required-ports setup start-docker-compose init-couchdb init-whisk-cli
+run: print-host check-required-ports setup start-docker-compose init-couchdb init-whisk-cli
+
+print-host:
+	echo "host ip address: ${DOCKER_HOST_IP}"
 
 .PHONY: check-required-ports
 check-required-ports:


### PR DESCRIPTION
For #58:

Detect the local IP, use the first IPv4 one from `ifconfig` that is not `127.0.0.1`, and use that instead of "localhost" as fallback if `DOCKER_HOST` is not set.

Tested on OSX. Should in theory work on *unix as well, but needs to be tested.