### PR TITLE
Add kafka-topics-ui to visualize the Kapka topic content

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -82,7 +82,7 @@ print-host:
 .PHONY: check-required-ports
 check-required-ports:
 	echo "checking required ports ... "
-	for port in 80 443 2888 5984 8085 8888 9092 2888; do \
+	for port in 80 443 2888 5984 8085 8888 9092 2888 8001; do \
 		pid=`lsof -Pi :$$port -sTCP:LISTEN -t` ; \
 		if [ ! -z "$$pid" ];  then echo "$$(tput setaf 1)Port $$port is taken by PID:$$pid.$$(tput sgr0)"; exit 1; fi; \
 	done

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -24,6 +24,7 @@ These ports must be available:
 - `8085` for OpenWhisk's Invoker
 - `8888` for OpenWhisk's Controller
 - `9092` for Kafka
+- `8001` for Kafka Topics UI
 
 # Quick Start
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -143,3 +143,32 @@ services:
     ports:
       - "80:80"
       - "443:443"
+
+  kafka-rest:
+    image: confluentinc/cp-kafka-rest:3.3.1
+    hostname: kafka-rest
+    environment:
+      - ACCESS_CONTROL_ALLOW_ORIGIN_DEFAULT="*"
+      - KAFKA_REST_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_REST_HOST_NAME=kafka-rest
+      - KAFKA_REST_LISTENERS=http://kafka-rest:8082
+      - KAFKA_REST_CONSUMER_REQUEST_TIMEOUT_MS=30000
+      - KAFKA_REST_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
+    links:
+      - zookeeper
+      - kafka
+    depends_on:
+      - zookeeper
+      - kafka
+
+  kafka-topics-ui:
+      image: landoop/kafka-topics-ui:0.9.3
+      environment:
+        - KAFKA_REST_PROXY_URL=http://kafka-rest:8082
+        - KAFKA_REST_BOOTSTRAP_SERVERS=PLAINTEXT://kafka:9092
+        - PROXY=true
+      ports:
+        - 8001:8000
+      links:
+        - kafka
+        - kafka-rest


### PR DESCRIPTION
Adds [kafka-topics][1] docker image to the docker-compose setup. This would allow inspecting the Kafka topic contents which is useful during development. It relies on [Kafka REST Proxy][2] for accessing Kafka topic content.

The ui is accessible over port 8001

[1]: https://github.com/Landoop/kafka-topics-ui
[2]: https://github.com/confluentinc/kafka-rest