### PR TITLE
Add variable to configure the controller and invoker image prefix

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -144,3 +144,9 @@ To start `docker-compose` with custom images used for running actions use the fo
 - `DOCKER_IMAGE_PREFIX` - specify a custom image prefix. I.e. ```DOCKER_IMAGE_PREFIX=my-prefix make quick-start```
 
 These 2 variable allow you to execute a JS action using the container `registry.example.com/my-prefix/nodejs6action`.
+
+## Local Docker containers for controllers and invokers
+
+By default this setup uses published images for controller and invokers from `openwhisk` namespace i.e. 
+`openwhisk/controller` and `openwhisk/invoker`. To make use of locally build images you can use `DOCKER_OW_IMAGE_PREFIX`
+variable i.e. `DOCKER_OW_IMAGE_PREFIX=whisk make quick-start`

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -37,7 +37,7 @@ services:
 
   # WHISK CONTROLLER
   controller:
-    image: openwhisk/controller
+    image: ${DOCKER_OW_IMAGE_PREFIX:-openwhisk}/controller
     command: /bin/sh -c "controller/bin/controller 0 >> /logs/controller-local_logs.log 2>&1"
     links:
       - db:db.docker
@@ -76,7 +76,7 @@ services:
 
   # WHISK INVOKER AGENT
   invoker:
-    image: openwhisk/invoker
+    image: ${DOCKER_OW_IMAGE_PREFIX:-openwhisk}/invoker
     command: /bin/sh -c "/invoker/bin/invoker 0 >> /logs/invoker-local_logs.log 2>&1"
     privileged: true
     pid: "host"


### PR DESCRIPTION
Current docker-compose if configured to use published controller and invoker images from `openwhisk` namespace. For local development one needs to modify the `docker-compose.xml` to change the namespace prefix used.

To simplify the development flow this pr introduces a new variable `DOCKER_OW_IMAGE_PREFIX` which can be used to define the image prefix for controller and invokers. By default it refers to published images

To use locally build image invoke make command in following way

    DOCKER_OW_IMAGE_PREFIX=whisk make quick-start
