### PR TITLE
Add support for installing optional packages.

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -93,6 +93,36 @@ check-required-ports:
 	done
 	echo " ... OK"
 
+.PHONY: check-alarm-ports
+check-alarm-ports:
+	echo "checking required ports ... "
+	for port in 8081; do \
+		pid=`lsof -Pi :$$port -sTCP:LISTEN -t` ; \
+		if [ ! -z "$$pid" ];  then echo "$$(tput setaf 1)Port $$port is taken by PID:$$pid.$$(tput sgr0)"; exit 1; fi; \
+	done
+	echo " ... OK"
+
+.PHONY: check-cloudant-ports
+check-cloudant-ports:
+	echo "checking required ports ... "
+	for port in 8082; do \
+		pid=`lsof -Pi :$$port -sTCP:LISTEN -t` ; \
+		if [ ! -z "$$pid" ];  then echo "$$(tput setaf 1)Port $$port is taken by PID:$$pid.$$(tput sgr0)"; exit 1; fi; \
+	done
+	echo " ... OK"
+
+.PHONY: check-kafka-ports
+check-kafka-ports:
+	echo "checking required ports ... "
+	for port in 5000; do \
+		pid=`lsof -Pi :$$port -sTCP:LISTEN -t` ; \
+		if [ ! -z "$$pid" ];  then echo "$$(tput setaf 1)Port $$port is taken by PID:$$pid.$$(tput sgr0)"; exit 1; fi; \
+	done
+	echo " ... OK"
+
+
+
+
 .PHONY: setup
 setup:
 	mkdir -p ~/tmp/openwhisk/apigateway/ssl
@@ -226,11 +256,11 @@ PACKAGE_CLOUDANT_HOME ?= ./openwhisk-package-cloudant
 PACKAGE_KAFKA_HOME ?= ./openwhisk-package-kafka
 CREATE_PACKAGE_STEPS = download-package- install-package- start-provider-
 
-create-provider-alarms: setup-providers $(addsuffix alarms,$(CREATE_PACKAGE_STEPS))
+create-provider-alarms: check-alarm-ports setup-providers $(addsuffix alarms,$(CREATE_PACKAGE_STEPS))
 
-create-provider-cloudant: setup-providers $(addsuffix cloudant,$(CREATE_PACKAGE_STEPS))
+create-provider-cloudant: check-cloudant-ports setup-providers $(addsuffix cloudant,$(CREATE_PACKAGE_STEPS))
 
-create-provider-kafka: setup-providers $(addsuffix kafka,$(CREATE_PACKAGE_STEPS))
+create-provider-kafka: check-kafka-ports setup-providers $(addsuffix kafka,$(CREATE_PACKAGE_STEPS))
 
 .PHONY: setup-providers
 setup-providers:

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -16,7 +16,6 @@ DOCKER_REGISTRY ?= ""
 DOCKER_IMAGE_PREFIX ?= openwhisk
 PROJECT_HOME ?= ./openwhisk-master
 WSK_CLI ?= $(PROJECT_HOME)/bin/wsk
-
 OPEN_WHISK_DB_PREFIX ?= local_
 
 DOCKER_KERNEL ?= $(shell docker version --format "{{.Server.KernelVersion}}")
@@ -78,7 +77,6 @@ download-cli:
 		cd $(PROJECT_HOME)/bin ; \
 		tar -xf wsk.tgz ; \
 	fi; 
-
 
 .PHONY: run
 run: print-host check-required-ports setup start-docker-compose init-couchdb init-whisk-cli
@@ -219,3 +217,55 @@ hello-world-perf-test: create-hello-world-function
 
 	$(WSK_CLI) -i action delete hello-perf
 	rm hello.js
+
+# Optional package configuration stages. These commands will install and set up
+# the alarms, cloudant and kakfa packages.
+PACKAGES = alarms cloudant kafka
+PACKAGE_ALARMS_HOME ?= ./openwhisk-package-alarms
+PACKAGE_CLOUDANT_HOME ?= ./openwhisk-package-cloudant
+PACKAGE_KAFKA_HOME ?= ./openwhisk-package-kafka
+CREATE_PACKAGE_STEPS = download-package- install-package- start-provider-
+
+create-provider-alarms: setup-providers $(addsuffix alarms,$(CREATE_PACKAGE_STEPS))
+
+create-provider-cloudant: setup-providers $(addsuffix cloudant,$(CREATE_PACKAGE_STEPS))
+
+create-provider-kafka: setup-providers $(addsuffix kafka,$(CREATE_PACKAGE_STEPS))
+
+.PHONY: setup-providers
+setup-providers:
+	printf "OPENWHISK_HOME=$(realpath $(PROJECT_HOME))\n" > ~/tmp/openwhisk/providers.env
+	printf "ENDPOINT_AUTH=`cat $(realpath $(PROJECT_HOME))/ansible/files/auth.whisk.system`\n" >> ~/tmp/openwhisk/providers.env
+	printf "HOST_MACHINE=$(DOCKER_HOST_IP)\n" >> ~/tmp/openwhisk/providers.env
+	printf "DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP)\n" >> ~/tmp/openwhisk/providers.env
+
+.PHONY: $(addprefix download-package-,$(PACKAGES))
+$(addprefix download-package-,$(PACKAGES)):
+	$(eval PACKAGE_NAME:= $(shell echo $(@) | cut -b 18-))
+	$(eval PACKAGE_HOME := $(PACKAGE_$(shell echo $(PACKAGE_NAME) |  tr 'a-z' 'A-Z')_HOME))
+	echo "Downloading package" $(PACKAGE_NAME) "into" $(PACKAGE_HOME)
+	rm -rf ./openwhisk-package-$(PACKAGE_NAME)*
+	if [ "$(PACKAGE_HOME)" = "./openwhisk-package-$(PACKAGE_NAME)" ]; then \
+	    curl -O ./openwhisk-package-$(PACKAGE_NAME).tar.gz -L https://api.github.com/repos/apache/incubator-openwhisk-package-$(PACKAGE_NAME)/tarball/master > ./openwhisk-package-$(PACKAGE_NAME).tar.gz; \
+	    mkdir openwhisk-package-$(PACKAGE_NAME); \
+	    tar -xf ./openwhisk-package-$(PACKAGE_NAME).tar.gz --strip 1 -C openwhisk-package-$(PACKAGE_NAME); \
+	else \
+	     echo "Skipping downloading the code from git as PACKAGE_HOME is not default:" $(PACKAGE_HOME); \
+	fi
+
+.PHONY: $(addprefix install-package-,$(PACKAGES))
+$(addprefix install-package-,$(PACKAGES)):
+	$(eval PACKAGE_NAME:= $(shell echo $(@) | cut -b 17-))
+	$(eval PACKAGE_HOME := $(PACKAGE_$(shell echo $(PACKAGE_NAME) |  tr 'a-z' 'A-Z')_HOME))
+	cd $(PACKAGE_HOME) && \
+	$(shell cat ~/tmp/openwhisk/providers.env) ./installCatalog.sh $(realpath $(PROJECT_HOME))/ansible/files/auth.whisk.system $(DOCKER_HOST_IP) "http://$(DOCKER_HOST_IP):5984" $(OPEN_WHISK_DB_PREFIX) $(DOCKER_HOST_IP)
+
+.PHONY: $(addprefix start-provider-,$(PACKAGES))
+$(addprefix start-provider-,$(PACKAGES)):
+	$(eval PACKAGE_NAME:= $(shell echo $(@) | cut -b 16-))
+	$(shell cat ~/tmp/openwhisk/providers.env) docker-compose -f docker-compose.yml -f docker-compose.packages.yml --project-name openwhisk up --no-recreate $(PACKAGE_NAME)provider 2>&1 > ~/tmp/openwhisk/docker-provider-compose.log &
+
+.PHONY: $(addprefix stop-provider-,$(PACKAGES))
+$(addprefix stop-provider-,$(PACKAGES)): setup-providers
+	$(eval PACKAGE_NAME:= $(shell echo $(@) | cut -b 15-))
+	$(shell cat ~/tmp/openwhisk/providers.env) docker-compose -f docker-compose.yml -f docker-compose.packages.yml --project-name openwhisk stop $(PACKAGE_NAME)provider

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -129,11 +129,51 @@ The result of the invokation should be printed on the terminal:
 
 Here is a [tutorial on getting started with actions](https://github.com/IBM-Bluemix/openwhisk-workshops/tree/master/bootcamp#start-your-engines).
 
+## Install Catalog Packages
+
+OpenWhisk has [numerous extra packages](https://github.com/apache/incubator-openwhisk-catalog) that are often installed into the `/whisk.system` namespace.
+
+***These are not included by default with the devtools  `make quick-start` command.***
+
+If you want to install these packages, run the following make command.
+
+```bash
+make add-catalog
+```
+
+Once the installation process has completed, you can check the `whisk.system` namespace to verify it those packages are now available.
+
+```
+wsk package list /whisk.system
+```
+
+## Install Feed Providers
+
+OpenWhisk supports [feed providers](https://github.com/apache/incubator-openwhisk/blob/master/docs/feeds.md) for invoking triggers from external event sources.
+
+***Feed provider packages are not included by default with the devtools  `make quick-start` command.***
+
+Providers for the [`alarms`](https://github.com/apache/incubator-openwhisk-package-alarms), [`kafka`](https://github.com/apache/incubator-openwhisk-package-kafka) and [`cloudant`](https://github.com/apache/incubator-openwhisk-package-cloudant) feeds can be installed individually using the `make` command.
+
+```bash
+make create-provider-alarms
+make create-provider-kafka
+make create-provider-cloudant
+```
+
+Once the installation process has completed, you can check the `whisk.system` namespace to verify it the feed packages are now available.
+
+```
+wsk package list /whisk.system
+```
+
 ## Logs
 
 - OpenWhisk Controller - `~/tmp/openwhisk/controller/logs/`
 - OpenWhisk Invoker - `~/tmp/openwhisk/invoker/logs/`
 - `docker-compose` logs - `~/tmp/openwhisk/docker-compose.log`
+- `docker-compose` feed provider logs - `~/tmp/openwhisk/docker-provider-compose.log`
+- Feed provider instance logs - `~/tmp/openwhisk/<feed_name>provider`
 - Action output such as stdout or console.log(): `wsk -i activation logs <activationId>`
 
 

--- a/docker-compose/docker-compose.packages.yml
+++ b/docker-compose/docker-compose.packages.yml
@@ -1,0 +1,63 @@
+version: '3'
+services:
+  alarmsprovider:
+    image: ${DOCKER_OW_IMAGE_PREFIX:-openwhisk}/alarmprovider
+    ports:
+      - "8081:8080"
+    links:
+      - db:db.docker
+      - apigateway:apigateway.docker
+      - redis:redis.docker
+    environment:
+      DB_PROTOCOL: http
+      DB_HOST: db.docker:5984
+      DB_USERNAME: whisk_admin
+      DB_PASSWORD: some_passw0rd
+      DB_PREFIX: ${OPEN_WHISK_DB_PREFIX:-local_}
+      HOST_MACHINE: ${HOST_MACHINE}
+      ROUTER_HOST: apigateway.docker
+      ENDPOINT_AUTH: ${ENDPOINT_AUTH}
+      REDIS_URL: redis://redis.docker:6379
+    volumes:
+      - ~/tmp/openwhisk/alarmsprovider:/logs
+  cloudantprovider:
+    image: ${DOCKER_OW_IMAGE_PREFIX:-openwhisk}/cloudantprovider
+    ports:
+      - "8082:8080"
+    links:
+      - db:db.docker
+      - apigateway:apigateway.docker
+      - redis:redis.docker
+    environment:
+      DB_PROTOCOL: http
+      DB_HOST: db.docker:5984
+      DB_USERNAME: whisk_admin
+      DB_PASSWORD: some_passw0rd
+      DB_PREFIX: ${OPEN_WHISK_DB_PREFIX:-local_}
+      HOST_MACHINE: ${HOST_MACHINE}
+      ROUTER_HOST: apigateway.docker
+      ENDPOINT_AUTH: ${ENDPOINT_AUTH}
+      REDIS_URL: redis://redis.docker:6379
+    volumes:
+      - ~/tmp/openwhisk/cloudantprovider:/logs
+  kafkaprovider:
+    image: ${DOCKER_OW_IMAGE_PREFIX:-openwhisk}/kafkaprovider
+    command: /bin/bash -c "cd KafkaFeedProvider && python -u app.py >> /logs/kafkaTrigger_logs.log 2>&1"
+    ports:
+      - "5000:5000"
+    links:
+      - db:db.docker
+      - apigateway:apigateway.docker
+      - redis:redis.docker
+    environment:
+      DB_URL: http://db.docker:5984
+      DB_USER: whisk_admin
+      DB_PASS: some_passw0rd
+      DB_PREFIX: ${OPEN_WHISK_DB_PREFIX:-local_}
+      LOCAL_DEV: "True" 
+      HOST_MACHINE: ${HOST_MACHINE}
+      ROUTER_HOST: apigateway.docker
+      ENDPOINT_AUTH: ${ENDPOINT_AUTH}
+      REDIS_URL: redis://redis.docker:6379
+    volumes:
+      - ~/tmp/openwhisk/kafkaprovider:/logs


### PR DESCRIPTION
Downloads package repos, installs shared actions and starts provider containers for alarms, kafka and cloudant packages.

```
$ make create-provider-alarms
```

Uses additional Docker compose file for managing container configuration for package provider images.