### PR TITLE
updated setup scripts to the latest changes

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -144,7 +144,7 @@ check-kafka-ports:
 .PHONY: setup
 setup:
 	mkdir -p ~/tmp/openwhisk/apigateway/ssl
-	cd $(PROJECT_HOME)/ansible/roles/nginx/files/ && ./genssl.sh $(DOCKER_HOST_IP) server
+	$(PROJECT_HOME)/ansible/files/genssl.sh $(DOCKER_HOST_IP) server $(PROJECT_HOME)/ansible/roles/nginx/files
 	cp $(PROJECT_HOME)/ansible/roles/nginx/files/*.pem ~/tmp/openwhisk/apigateway/ssl
 	cp -r ./apigateway/* ~/tmp/openwhisk/apigateway/
 	> ~/tmp/openwhisk/local.env


### PR DESCRIPTION
This PR reflects a change from https://github.com/apache/incubator-openwhisk/pull/3258 that moved `genssl.sh` into another folder, in order to generate ssl certs needed for data-in-flight encryption.