### PR TITLE
Fix to fallback when LOCAL_IP cannot be obtained

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -3,6 +3,10 @@ UNAME_STR ?= $(shell uname)
 # detect local ip of host as this is needed within containers to find the openwhisk API container
 ifeq ("$(UNAME_STR)","Linux")
 	LOCAL_IP=$(shell route | grep default | tr -s " " | cut -d " " -f 8 | xargs /sbin/ifconfig | grep "inet addr:" | cut -d ":" -f 2 | cut -d " " -f 1)
+	# inet addr: not present, trying with inet.
+	ifeq ($(LOCAL_IP), )
+		LOCAL_IP=$(shell route | grep default | tr -s " " | cut -d " " -f 8 | xargs /sbin/ifconfig | grep "inet " | tr -s " " | cut -d " " -f 3)
+	endif
 else
 	LOCAL_IP ?= $(shell ifconfig | grep "inet " | grep -v 127.0.0.1 | cut -d\  -f2 | head -1)
 endif

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -5,10 +5,10 @@ ifeq ("$(UNAME_STR)","Linux")
 	LOCAL_IP=$(shell route | grep default | tr -s " " | cut -d " " -f 8 | xargs /sbin/ifconfig | grep "inet addr:" | cut -d ":" -f 2 | cut -d " " -f 1)
 else
 	LOCAL_IP ?= $(shell ifconfig | grep "inet " | grep -v 127.0.0.1 | cut -d\  -f2 | head -1)
-	# if no IP was found, fallback to "localhost"
-	ifeq ($(LOCAL_IP), )
-		LOCAL_IP = "localhost"
-	endif
+endif
+# if no IP was found, fallback to "localhost"
+ifeq ($(LOCAL_IP), )
+	LOCAL_IP = "localhost"
 endif
 
 DOCKER_HOST_IP ?= $(shell echo ${DOCKER_HOST} | grep -o "[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}" || echo ${LOCAL_IP})


### PR DESCRIPTION
I've tried to do make quick-start from CentOS 7
I noticed that LOCAL_IP cannot be obtained  within CentOS 7 the way Makefile tries to do so.
I supposed fallback to localhost should execute but I realized that fallback conditional is actually intended to be executed only on systems other than Linux.
I propose this change to allow fallback conditional to be executed the same way on Linux and no-Linux systems
I Also added support for getting LOCAL_IP on Linux distros where /sbin/ifconfig command provides ip address description as: inet xx.xx.xx.xx instead of inet addr: xx.xx.xx.xx