### PR TITLE
Merge outdated docker_build makefile target.

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -78,14 +78,9 @@ quick-start-info:
 	echo "$$(tput setaf 2)To stop openwhisk use: $$(tput setaf 4)make destroy$$(tput sgr0)"
 
 docker_build:
-	echo "building the docker images short list ... "
+	echo "building the openwhisk core docker images ... "
 	cd $(OPENWHISK_PROJECT_HOME) && \
-		./gradlew distDocker -PdockerImagePrefix=$(DOCKER_IMAGE_PREFIX) -x :actionRuntimes:pythonAction:distDocker  -x :actionRuntimes:python2Action:distDocker -x actionRuntimes:swift3.1.1Action:distDocker -x actionRuntimes:swift4.1Action:distDocker -x :actionRuntimes:javaAction:distDocker
-
-docker_build_full:
-	echo "building the docker images full list ... "
-	cd $(OPENWHISK_PROJECT_HOME) && \
-		./gradlew distDocker -PdockerImagePrefix=$(DOCKER_IMAGE_PREFIX)
+		./gradlew distDocker -PdockerImagePrefix=$(DOCKER_IMAGE_PREFIX) 
 
 docker_pull:
 	echo "pulling the docker images short list... "

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -82,7 +82,7 @@ make restart-controller
 
 * Check the [issue tracker](https://github.com/apache/incubator-openwhisk-devtools/issues) for more.
 
-# Build or Pull
+# Pull and build local OpenWhisk core images
 
 You can pull pre-built image
 ```bash
@@ -95,7 +95,7 @@ This command pulls the docker images for local testing and development.
 make docker_build
 ```
 
-This command builds the docker images for local testing and development.
+This command builds the opewnhisk core docker images for local testing and development.
 
 
 # Start


### PR DESCRIPTION
Since `actionRuntimes` had been removed from upstream codebase. Merge
two `docker_build*` makefile targets for avoiding misunderstanding.

Related issue: #141 

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>