### PR TITLE
Use 0.9.0 release as default sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-openwhisk-master
-openwhisk-master*
+openwhisk-src
 
 *.iml
 .idea

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -45,12 +45,12 @@ add-catalog: download-catalog init-catalog
 
 .PHONY: download-src
 download-src:
-	if [[ -z `ls -A $(OPENWHISK_PROJECT_HOME) 2>/dev/null` || "$(OPENWHISK_VERSION)" == "master" ]]; then \
+	if [ ! -d $(OPENWHISK_PROJECT_HOME) -o "$(OPENWHISK_VERSION)" = "master" ]; then \
         echo "Downloading source tar ball $(OPENWHISK_VERSION)...."; \
-	    if [ "$(OPENWHISK_VERSION)" == "master" ]; then \
+	    if [ "$(OPENWHISK_VERSION)" = "master" ]; then \
 	        rm -rf "$(OPENWHISK_PROJECT_HOME)"; \
 	        curl -o ./openwhisk-src.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/master.tar.gz; \
-        elif [ "$(OPENWHISK_VERSION)" == "0.9.0" ]; then \
+        elif [ "$(OPENWHISK_VERSION)" = "0.9.0" ]; then \
 	        curl -o ./openwhisk-src.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/0.9.0-incubating.tar.gz; \
         fi; \
         echo "Unpacking tarball."; \

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -18,8 +18,8 @@ endif
 DOCKER_HOST_IP ?= $(shell echo ${DOCKER_HOST} | grep -o "[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}" || echo ${LOCAL_IP})
 DOCKER_REGISTRY ?= ""
 DOCKER_IMAGE_PREFIX ?= openwhisk
-OPENWHISK_PROJECT_HOME_DEFAULT = "./openwhisk-0.9.0"
-OPENWHISK_PROJECT_HOME ?= $OPENWHISK_PROJECT_HOME_DEFAULT
+OPENWHISK_VERSION ?= master
+OPENWHISK_PROJECT_HOME ?= ./openwhisk-src
 OPENWHISK_CATALOG_HOME ?= ./openwhisk-catalog
 WSK_CLI ?= $(OPENWHISK_PROJECT_HOME)/bin/wsk
 OPEN_WHISK_DB_PREFIX ?= local_
@@ -45,15 +45,20 @@ add-catalog: download-catalog init-catalog
 
 .PHONY: download
 download:
-	if [ "$(OPENWHISK_PROJECT_HOME)" = "$(OPENWHISK_PROJECT_HOME_DEFAULT)" ]; then \
-	    rm -rf $(OPENWHISK_PROJECT_HOME_DEFAULT)* \
-        echo "Downloading source tar ball...."; \
-	    curl -o ./openwhisk-0.9.0.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/0.9.0-incubating.tar.gz; \
+	if [[ -z `ls -A $(OPENWHISK_PROJECT_HOME) 2>/dev/null` || "$(OPENWHISK_VERSION)" == "master" ]]; then \
+        echo "Downloading source tar ball $(OPENWHISK_VERSION)...."; \
+	    if [ "$(OPENWHISK_VERSION)" == "master" ]; then \
+	        rm -rf "$(OPENWHISK_PROJECT_HOME)"; \
+	        curl -o ./openwhisk-src.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/master.tar.gz; \
+        elif [ "$(OPENWHISK_VERSION)" == "0.9.0" ]; then \
+	        curl -o ./openwhisk-src.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/0.9.0-incubating.tar.gz; \
+        fi; \
         echo "Unpacking tarball."; \
-	    mkdir $(OPENWHISK_PROJECT_HOME_DEFAULT); \
-	    tar -xf ./openwhisk-0.9.0.tar.gz --strip 1 -C $(OPENWHISK_PROJECT_HOME_DEFAULT); \
+	    mkdir -p $(OPENWHISK_PROJECT_HOME); \
+	    tar -xf ./openwhisk-src.tar.gz --strip 1 -C $(OPENWHISK_PROJECT_HOME); \
+	    rm ./openwhisk-src.tar.gz; \
 	else \
-	     echo "Skipping downloading the code from git as OPENWHISK_PROJECT_HOME is not default:" $(OPENWHISK_PROJECT_HOME); \
+	     echo "Skipping downloading the code as OPENWHISK_PROJECT_HOME is set to " $(OPENWHISK_PROJECT_HOME); \
 	fi
 
 .PHONY: download-catalog
@@ -106,7 +111,7 @@ docker_pull_full:
 
 download-cli:
 	echo "downloading the CLI tool ... "
-	if [ "$(OPENWHISK_PROJECT_HOME)" = "$(OPENWHISK_PROJECT_HOME_DEFAULT)" ]; then \
+	if [ ! -e "$(WSK_CLI)" ]; then \
         if [ "$(UNAME_STR)" = "Darwin" ]; then \
           echo "downloading cli for mac" ; \
           curl -o $(OPENWHISK_PROJECT_HOME)/bin/wsk.zip -L https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-mac-amd64.zip ; \
@@ -119,7 +124,7 @@ download-cli:
             tar -xf wsk.tgz ; \
         fi; \
 	else \
-         echo "Skipping downloading the cli from git as OPENWHISK_PROJECT_HOME is not default:" $(OPENWHISK_PROJECT_HOME); \
+         echo "Skipping downloading the cli as OPENWHISK_PROJECT_HOME is set to " $(OPENWHISK_PROJECT_HOME); \
 	fi
 
 .PHONY: run

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -18,7 +18,8 @@ endif
 DOCKER_HOST_IP ?= $(shell echo ${DOCKER_HOST} | grep -o "[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}" || echo ${LOCAL_IP})
 DOCKER_REGISTRY ?= ""
 DOCKER_IMAGE_PREFIX ?= openwhisk
-OPENWHISK_PROJECT_HOME ?= ./openwhisk-master
+OPENWHISK_PROJECT_HOME_DEFAULT = "./openwhisk-0.9.0"
+OPENWHISK_PROJECT_HOME ?= $OPENWHISK_PROJECT_HOME_DEFAULT
 OPENWHISK_CATALOG_HOME ?= ./openwhisk-catalog
 WSK_CLI ?= $(OPENWHISK_PROJECT_HOME)/bin/wsk
 OPEN_WHISK_DB_PREFIX ?= local_
@@ -44,21 +45,21 @@ add-catalog: download-catalog init-catalog
 
 .PHONY: download
 download:
-	rm -rf ./openwhisk-master*
-	if [ "$(OPENWHISK_PROJECT_HOME)" = "./openwhisk-master" ]; then \
+	if [ "$(OPENWHISK_PROJECT_HOME)" = "$(OPENWHISK_PROJECT_HOME_DEFAULT)" ]; then \
+	    rm -rf $(OPENWHISK_PROJECT_HOME_DEFAULT)* \
         echo "Downloading source tar ball...."; \
-	    curl -o ./openwhisk-master.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/master.tar.gz; \
+	    curl -o ./openwhisk-0.9.0.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/0.9.0-incubating.tar.gz; \
         echo "Unpacking tarball."; \
-	    mkdir openwhisk-master; \
-	    tar -xf ./openwhisk-master.tar.gz --strip 1 -C openwhisk-master; \
+	    mkdir $(OPENWHISK_PROJECT_HOME_DEFAULT); \
+	    tar -xf ./openwhisk-0.9.0.tar.gz --strip 1 -C $(OPENWHISK_PROJECT_HOME_DEFAULT); \
 	else \
 	     echo "Skipping downloading the code from git as OPENWHISK_PROJECT_HOME is not default:" $(OPENWHISK_PROJECT_HOME); \
 	fi
 
 .PHONY: download-catalog
 download-catalog:
-	rm -rf ./openwhisk-catalog*
 	if [ "$(OPENWHISK_CATALOG_HOME)" = "./openwhisk-catalog" ]; then \
+	    rm -rf ./openwhisk-catalog* \
 	    curl -O ./openwhisk-catalog.tar.gz -L https://api.github.com/repos/apache/incubator-openwhisk-catalog/tarball/master > ./openwhisk-catalog.tar.gz; \
 	    mkdir openwhisk-catalog; \
 	    tar -xf ./openwhisk-catalog.tar.gz --strip 1 -C openwhisk-catalog; \
@@ -105,7 +106,7 @@ docker_pull_full:
 
 download-cli:
 	echo "downloading the CLI tool ... "
-	if [ "$(OPENWHISK_PROJECT_HOME)" = "./openwhisk-master" ]; then \
+	if [ "$(OPENWHISK_PROJECT_HOME)" = "$(OPENWHISK_PROJECT_HOME_DEFAULT)" ]; then \
         if [ "$(UNAME_STR)" = "Darwin" ]; then \
           echo "downloading cli for mac" ; \
           curl -o $(OPENWHISK_PROJECT_HOME)/bin/wsk.zip -L https://github.com/apache/incubator-openwhisk-cli/releases/download/latest/OpenWhisk_CLI-latest-mac-amd64.zip ; \

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -39,12 +39,12 @@ endif
 #   2. then it starts all components using docker-compose
 #   3. it runs a sample hello-world function
 #   To stop and cleanup the environment use: make destroy
-quick-start: download download-cli docker_pull run quick-start-pause hello-world quick-start-info
+quick-start: download-src download-cli docker_pull run quick-start-pause hello-world quick-start-info
 
 add-catalog: download-catalog init-catalog
 
-.PHONY: download
-download:
+.PHONY: download-src
+download-src:
 	if [[ -z `ls -A $(OPENWHISK_PROJECT_HOME) 2>/dev/null` || "$(OPENWHISK_VERSION)" == "master" ]]; then \
         echo "Downloading source tar ball $(OPENWHISK_VERSION)...."; \
 	    if [ "$(OPENWHISK_VERSION)" == "master" ]; then \
@@ -336,7 +336,7 @@ hello-world-perf-test: create-hello-world-function
 	rm hello.js
 
 .PHONY: pull
-pull: download setup
+pull: download-src setup
 	docker-compose --project-name openwhisk pull
 
 # Optional package configuration stages. These commands will install and set up

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -42,12 +42,13 @@ At the end of the execution it prints the output of the function:
 ```
 
 If `OPENWHISK_PROJECT_HOME` variable is set ( i.e. `OPENWHISK_PROJECT_HOME=/path/to/openwhisk make quick-start`)
-then the command skips downloading the `master` branch and uses instead the source code found in the `PROJECT_HOME` folder.
+then the command skips downloading the sources and uses instead the source code found in the `OPENWHISK_PROJECT_HOME` folder.
 This is useful for working with a local clone, making changes to the code, and run it with `docker-compose`.
 
 This is the set of environment variables that can be set:
 
 * `OPENWHISK_PROJECT_HOME` - a checkout of [openwhisk](https://github.com/apache/incubator-openwhisk)
+* `OPENWHISK_VERSION` - defaults to `master` but can be set to [releases](https://github.com/apache/incubator-openwhisk/releases) such as `0.9.0`
 * `OPENWHISK_CATALOG_HOME` - a checkout of [openwhisk-catalog](https://github.com/apache/incubator-openwhisk-catalog)
 * `WSK_CLI` - the directory where the [`wsk` command line tool](https://github.com/apache/incubator-openwhisk-cli) can be found
 * `DOCKER_IMAGE_PREFIX` - the prefix of the docker images used for actions. If you are building and testing checkouts of runtimes locally, then consider setting this to `whisk`.


### PR DESCRIPTION
Now with the first official release one could use that to download sources in the quick-start deployment.