### PR TITLE
adding a note about -i

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -145,6 +145,9 @@ The result of the invocation should be printed on the terminal:
 
 Here is a [tutorial on getting started with actions](https://github.com/IBM-Bluemix/openwhisk-workshops/tree/master/bootcamp#start-your-engines).
 
+Note that these commands will use `-i` to bypass security check as we are running
+it on localhost
+
 ## Install Catalog Packages
 
 OpenWhisk has [numerous extra packages](https://github.com/apache/incubator-openwhisk-catalog) that are often installed into the `/whisk.system` namespace.


### PR DESCRIPTION
Hey guys, thanks for the great project! 

I was going through the documentation to set up a playground environment locally but I was immediately blocked when I was trying to create a custom action other than just `hello-world` (or even any interactions using `wsk` was giving errors). In short, I was basically getting

```
error: Unable to obtain the list of actions for namespace 'guest': Get https://localhost/api/v1/namespaces/guest/actions?limit=30&skip=0: x509: certificate signed by unknown authority
``` 

After a half an hour worth of investigation, I realised that `make hello-world` was using `-i` to create the functions, which bypasses the SSL and I was able to create, delete and list using `wsk` by adding `-i`. To help others to avoid the same issue, I propose adding a short note to inform the new users about `-i` usage in the makefile.