### PR TITLE
Update for memory-based loadbalancing config change

### DIFF
--- a/docker-compose/docker-whisk-controller.env
+++ b/docker-compose/docker-whisk-controller.env
@@ -52,8 +52,6 @@ CONFIG_kamon_statsd_port=8125
 LOADBALANCER_ACTIVATIONCOUNTBEFORENEXTINVOKER=10
 LOADBALANCER_USERMEMORY="1024 m"
 
-INVOKER_NUMCORE=2
-INVOKER_CORESHARE=2
 INVOKER_USE_RUNC=False
 INVOKER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098
 INVOKER_INSTANCES=1

--- a/docker-compose/docker-whisk-controller.env
+++ b/docker-compose/docker-whisk-controller.env
@@ -36,7 +36,8 @@ LIMITS_ACTIONS_SEQUENCE_MAXLENGTH=20
 
 CONFIG_whisk_loadbalancer_blackboxFraction=0.1
 CONFIG_kamon_statsd_port=8125
-CONFIG_whisk_loadbalancer_invokerUserMemory=1024 m
+CONFIG_whisk_loadbalancer_invokerUserMemory="1024 m"
+CONFIG_whisk_containerPool_userMemory="1024 m"
 
 CONTROLLER_BLACKBOXFRACTION=0.10
 CONTROLLER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098
@@ -49,7 +50,7 @@ METRICS_LOG=True
 CONFIG_kamon_statsd_port=8125
 
 LOADBALANCER_ACTIVATIONCOUNTBEFORENEXTINVOKER=10
-LOADBALANCER_INVOKERBUSYTHRESHOLD=16
+LOADBALANCER_USERMEMORY="1024 m"
 
 INVOKER_NUMCORE=2
 INVOKER_CORESHARE=2

--- a/docker-compose/docker-whisk-controller.env
+++ b/docker-compose/docker-whisk-controller.env
@@ -36,8 +36,8 @@ LIMITS_ACTIONS_SEQUENCE_MAXLENGTH=20
 
 CONFIG_whisk_loadbalancer_blackboxFraction=0.1
 CONFIG_kamon_statsd_port=8125
-CONFIG_whisk_loadbalancer_invokerUserMemory="1024 m"
-CONFIG_whisk_containerPool_userMemory="1024 m"
+CONFIG_whisk_loadbalancer_invokerUserMemory=1024 m
+CONFIG_whisk_containerPool_userMemory=1024 m
 
 CONTROLLER_BLACKBOXFRACTION=0.10
 CONTROLLER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098
@@ -50,7 +50,7 @@ METRICS_LOG=True
 CONFIG_kamon_statsd_port=8125
 
 LOADBALANCER_ACTIVATIONCOUNTBEFORENEXTINVOKER=10
-LOADBALANCER_USERMEMORY="1024 m"
+LOADBALANCER_USERMEMORY=1024 m
 
 INVOKER_USE_RUNC=False
 INVOKER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098

--- a/docker-compose/docker-whisk-controller.env
+++ b/docker-compose/docker-whisk-controller.env
@@ -36,7 +36,7 @@ LIMITS_ACTIONS_SEQUENCE_MAXLENGTH=20
 
 CONFIG_whisk_loadbalancer_blackboxFraction=0.1
 CONFIG_kamon_statsd_port=8125
-CONFIG_whisk_loadbalancer_invokerBusyThreshold=16
+CONFIG_whisk_loadbalancer_invokerUserMemory=1024 m
 
 CONTROLLER_BLACKBOXFRACTION=0.10
 CONTROLLER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098

--- a/docker-compose/docker-whisk-controller.env
+++ b/docker-compose/docker-whisk-controller.env
@@ -36,8 +36,8 @@ LIMITS_ACTIONS_SEQUENCE_MAXLENGTH=20
 
 CONFIG_whisk_loadbalancer_blackboxFraction=0.1
 CONFIG_kamon_statsd_port=8125
-CONFIG_whisk_loadbalancer_invokerUserMemory=1024 m
-CONFIG_whisk_containerPool_userMemory=1024 m
+CONFIG_whisk_loadbalancer_invokerUserMemory=1024m
+CONFIG_whisk_containerPool_userMemory=1024m
 
 CONTROLLER_BLACKBOXFRACTION=0.10
 CONTROLLER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098
@@ -50,7 +50,7 @@ METRICS_LOG=True
 CONFIG_kamon_statsd_port=8125
 
 LOADBALANCER_ACTIVATIONCOUNTBEFORENEXTINVOKER=10
-LOADBALANCER_USERMEMORY=1024 m
+LOADBALANCER_USERMEMORY=1024m
 
 INVOKER_USE_RUNC=False
 INVOKER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098


### PR DESCRIPTION
`CONFIG_whisk_loadbalancer_invokerBusyThreshold` has been replaced with `CONFIG_whisk_loadbalancer_invokerUserMemory`.

Before this fix the controller was triggering the following error:
```
[2018-08-24T19:26:24.437Z] [INFO] [#tid_sid_controller] [Controller] starting controller instance 0 [marker:controller_startup0_count:3021]
[2018-08-24T19:26:25.375Z] [INFO] [#tid_sid_dispatcher] [MessageFeed] handler capacity = 128, pipeline fill at = 128, pipeline depth = 256
Exception in thread "main" pureconfig.error.ConfigReaderException: Cannot convert configuration to a whisk.core.loadBalancer.ShardingContainerPoolBalancerConfig. Failures are:
  at 'whisk.loadbalancer':
    - Key not found: 'invoker-user-memory'.

	at pureconfig.package$.getResultOrThrow(package.scala:138)
	at pureconfig.package$.loadConfigOrThrow(package.scala:160)
	at whisk.core.loadBalancer.ShardingContainerPoolBalancer.<init>(ShardingContainerPoolBalancer.scala:159)
	at whisk.core.loadBalancer.ShardingContainerPoolBalancer$.instance(ShardingContainerPoolBalancer.scala:437)
	at whisk.core.controller.Controller.<init>(Controller.scala:117)
	at whisk.core.controller.Controller$.main(Controller.scala:258)
	at whisk.core.controller.Controller.main(Controller.scala)
```