### PR TITLE
List all ports that are occupied in check-required-ports

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -131,11 +131,17 @@ print-host:
 .PHONY: check-required-ports
 check-required-ports:
 	echo "checking required ports ... "
+	@occupiedports=0; \
 	for port in 2888 5984 8085 8888 9092 8001; do \
 		pid=`lsof -Pi :$$port -sTCP:LISTEN -t` ; \
-		if [ ! -z "$$pid" ];  then echo "$$(tput setaf 1)Port $$port is taken by PID:$$pid.$$(tput sgr0)"; exit 1; fi; \
-	done
-	echo " ... OK"
+		if [ ! -z "$$pid" ];  then let "occupiedports+=1" ; echo "$$(tput setaf 1)Port $$port is taken by PID:$$pid.$$(tput sgr0)"; fi; \
+	done; \
+	if [ "$$occupiedports" = 0 ]; then \
+		echo " ... OK"; \
+	else \
+		echo "$$(tput setaf 2)Ports occupied. To stop openwhisk use: $$(tput setaf 4)make destroy$$(tput setaf 2) or: $$(tput setaf 4)make stop$$(tput sgr0)"; \
+		exit 1; \
+	fi
 
 .PHONY: check-alarm-ports
 check-alarm-ports:


### PR DESCRIPTION
Instead of exiting on the first port that is occupied this pull request lists all ports that are occupied. And it adds some helpful text to let you know how to shut down OpenWhisk, so the ports aren't occupied anymore.

### Before
```bash
checking required ports ...
Port 2888 is taken by PID:1923.
make: *** [check-required-ports] Error 1
```

### After
```bash
checking required ports ...
Port 2888 is taken by PID:1923.
Port 5984 is taken by PID:1923.
Port 8085 is taken by PID:1923.
Port 8888 is taken by PID:1923.
Port 9092 is taken by PID:1923.
Port 8001 is taken by PID:1923.
Ports occupied. To stop openwhisk use: make destroy or: make stop
make: *** [check-required-ports] Error 1
```
