### PR TITLE
Add wait-for-docker-compose-up

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -150,7 +150,7 @@ download-cli:
 	fi
 
 .PHONY: run
-run: print-host check-required-ports setup start-docker-compose init-couchdb init-whisk-cli init-api-management
+run: print-host check-required-ports setup start-docker-compose wait-for-docker-compose-up init-couchdb init-whisk-cli init-api-management
 
 print-host:
 	echo "host ip address: ${DOCKER_HOST_IP}"
@@ -259,7 +259,45 @@ restart-invoker:
 
 .PHONY: start-docker-compose
 start-docker-compose:
-	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk up 2>&1 > ~/tmp/openwhisk/docker-compose.log &
+	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk up --abort-on-container-exit 2>&1 > ~/tmp/openwhisk/docker-compose.log &
+
+.PHONY: wait-for-docker-compose-up
+wait-for-docker-compose-up:
+	echo "Waiting till all containers are powered up... ";
+	sleep 1;
+	@trycount=0; \
+	trycounttimeout=30; \
+	up=`docker-compose --project-name openwhisk ps | grep Up -c`; \
+	servicescount=`docker-compose config --services | wc -l | xargs`; \
+	function docker_ps { \
+		docker ps --format 'table {{.Image}}\t{{.Status}}' --filter "label=com.docker.compose.project=openwhisk" -a; \
+	}; \
+	function echo_output { \
+		if [ "$(VERBOSE)" != "true" ]; then return;	fi; \
+		output=$$(docker_ps); \
+		echoprefix=""; \
+		if [ "$$trycount" != 0 ]; then \
+			lines=$$(echo "$$output" | wc -l | xargs); \
+			echoprefix="\033[$${lines}A\033[0J"; \
+		fi; \
+		echo "$${echoprefix}$$output"; \
+	}; \
+	until [ "$$up" -eq "$$servicescount" ]; do \
+		echo_output; \
+	  sleep 1; \
+	  up=`docker-compose --project-name openwhisk ps | grep Up -c`; \
+	  if [ "$$up" != "$$servicescount" ]; then \
+	    if [ "$$trycount" -eq "$$trycounttimeout" ]; then \
+				echo "\n$$(docker_ps)"; \
+	      echo "\nERROR: Timed out waiting for docker services to launch..."; \
+	      exit 1; \
+	    else \
+	      let "trycount+=1"; \
+	    fi; \
+	  fi; \
+	done; \
+	echo_output;
+	echo " ... OK: all containers up!"
 
 .PHONY: stop
 stop:

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -267,12 +267,12 @@ wait-for-docker-compose-up:
 	sleep 1;
 	@trycount=0; \
 	trycounttimeout=30; \
-	up=`docker-compose --project-name openwhisk ps | grep Up -c`; \
-	servicescount=`docker-compose config --services | wc -l | xargs`; \
-	function docker_ps { \
+	up=`$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk ps | grep Up -c`; \
+	servicescount=`$(shell cat ~/tmp/openwhisk/local.env) docker-compose config --services | wc -l | xargs`; \
+	docker_ps() { \
 		docker ps --format 'table {{.Image}}\t{{.Status}}' --filter "label=com.docker.compose.project=openwhisk" -a; \
 	}; \
-	function echo_output { \
+	echo_output() { \
 		if [ "$(VERBOSE)" != "true" ]; then return;	fi; \
 		output=$$(docker_ps); \
 		echoprefix=""; \
@@ -285,7 +285,7 @@ wait-for-docker-compose-up:
 	until [ "$$up" -eq "$$servicescount" ]; do \
 		echo_output; \
 	  sleep 1; \
-	  up=`docker-compose --project-name openwhisk ps | grep Up -c`; \
+	  up=`$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk ps | grep Up -c`; \
 	  if [ "$$up" != "$$servicescount" ]; then \
 	    if [ "$$trycount" -eq "$$trycounttimeout" ]; then \
 				echo "\n$$(docker_ps)"; \


### PR DESCRIPTION
Locally I was having issues where `make quick-start` would start interacting with containers before they where up and running. This triggered me to build `make wait-for-docker-compose-up`.

`wait-for-compose-up` waits until all docker containers are up and running before continuing. It times out after 30 seconds and outputs the status of all the containers that are and aren't running at that point in time to allow you to understand what is going wrong.

`wait-for-compose-up` is also added as part of `quick-start`.

`wait-for-compose-up` also includes a special mode when running `VERBOSE=true` where it will give you a live update on what the container status is. See screen capture of that mode below:

![wait-for-docker-compose-up](https://user-images.githubusercontent.com/4106/44740216-df843f00-aac7-11e8-9b60-867de18643d8.gif)
