### PR TITLE
Make CouchDB align with upstream version.

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: couchdb:1.6
+    image: apache/couchdb:2.1
     ports:
       - "5984:5984"
     environment:


### PR DESCRIPTION
Bump couchdb image into apache/couchdb:2.1. Since couchdb 1 vs 2 is not 100% compatible that might cause potential problems if any of upstream changes.

Ref: https://blog.couchdb.org/2016/08/17/migrating-to-couchdb-2-0/

Is keeping couchdb at 1.6 version intentional? I've reviewed commit history and I guess it's not?

In kube deploy, 2.1 version is used as well.

Signed-off-by: Tzu-Chiao Yeh <su3g4284zo6y7@gmail.com>