### PR TITLE
Do not print output when cheking if minio is up

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -213,7 +213,7 @@ setup:
 	cp -r ./apigateway/rclone ~/tmp/openwhisk
 	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk up minio 2>&1 > ~/tmp/openwhisk/setup.log &
 	echo "pinging minio..."
-	until (curl --silent http://$(DOCKER_HOST_IP):9001/); do printf '.'; sleep 5; done
+	until (curl --silent http://$(DOCKER_HOST_IP):9001/ > /dev/null); do printf '.'; sleep 5; done
 	echo " ... OK"
 	docker run --rm -v ~/tmp/openwhisk/rclone:/root/.config/rclone \
 					--link="openwhisk_minio_1:minio.docker" --network=openwhisk_default \


### PR DESCRIPTION
When checking if the minio container is up and running, the followign
output is printed:

    pinging minio...
    <?xml version="1.0" encoding="UTF-8"?>
    <Error><Code>AccessDenied</Code><Message>Access Denied.</Message><Key></Key><BucketName></BucketName><Resource>/</Resource><RequestId>3L137</RequestId><HostId>3L137</HostId></Error> ... OK

This is a misleading message, as it shows an error ("Access Denied") but
there is no problem at all, so we can drop the curl output.