### PR TITLE
effective user in controller is owuser

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -38,7 +38,7 @@ services:
   # WHISK CONTROLLER
   controller:
     image: ${DOCKER_OW_IMAGE_PREFIX:-openwhisk}/controller
-    command: /bin/sh -c "exec /init.sh 0 >> /logs/controller-local_logs.log 2>&1"
+    command: /bin/sh -c "exec /init.sh 0 >> /home/owuser/controller-local_logs.log 2>&1"
     links:
       - db:db.docker
       - kafka:kafka.docker


### PR DESCRIPTION
Fixes #167 

The new effective user changed in the controller recently to be `owuser`
https://github.com/apache/incubator-openwhisk/commit/f7afa71b1156ea193fc1df4bfcdf39fdb64a50c5#diff-8f445fbdf6253dd176975ff6c629def4R23
```
USER ${NOT_ROOT_USER}
```
it can't write logs `/logs` it doesn't have permissions.
