### PR TITLE
[docker-compose] Fixed a bug in download-src

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -46,20 +46,15 @@ add-catalog: download-catalog init-catalog
 
 .PHONY: download-src
 download-src:
-	if [ ! -d $(OPENWHISK_PROJECT_HOME) -o "$(OPENWHISK_VERSION)" = "master" ]; then \
-        echo "Downloading source tar ball $(OPENWHISK_VERSION)...."; \
-	    if [ "$(OPENWHISK_VERSION)" = "master" ]; then \
-	        rm -rf "$(OPENWHISK_PROJECT_HOME)"; \
-	        curl -o ./openwhisk-src.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/master.tar.gz; \
-        elif [ "$(OPENWHISK_VERSION)" = "0.9.0" ]; then \
-	        curl -o ./openwhisk-src.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/0.9.0-incubating.tar.gz; \
-        fi; \
-        echo "Unpacking tarball."; \
+	if [ ! $(OPENWHISK_PROJECT_HOME) = "./openwhisk-src" ]; then \
+		echo "Skipping downloading the code as OPENWHISK_PROJECT_HOME is set to " $(OPENWHISK_PROJECT_HOME); \
+	else \
+		rm -rf ./openwhisk-src; \
+		curl -o ./openwhisk-src.tar.gz -L https://github.com/apache/incubator-openwhisk/archive/$(OPENWHISK_VERSION).tar.gz; \
+		echo "Unpacking tarball."; \
 	    mkdir -p $(OPENWHISK_PROJECT_HOME); \
 	    tar -xf ./openwhisk-src.tar.gz --strip 1 -C $(OPENWHISK_PROJECT_HOME); \
 	    rm ./openwhisk-src.tar.gz; \
-	else \
-	     echo "Skipping downloading the code as OPENWHISK_PROJECT_HOME is set to " $(OPENWHISK_PROJECT_HOME); \
 	fi
 
 .PHONY: download-catalog

--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -48,7 +48,7 @@ This is useful for working with a local clone, making changes to the code, and r
 This is the set of environment variables that can be set:
 
 * `OPENWHISK_PROJECT_HOME` - a checkout of [openwhisk](https://github.com/apache/incubator-openwhisk)
-* `OPENWHISK_VERSION` - defaults to `master` but can be set to [releases](https://github.com/apache/incubator-openwhisk/releases) such as `0.9.0`
+* `OPENWHISK_VERSION` - defaults to `master` but can be set to [releases](https://github.com/apache/incubator-openwhisk/releases) such as `0.9.0-incubating`
 * `OPENWHISK_CATALOG_HOME` - a checkout of [openwhisk-catalog](https://github.com/apache/incubator-openwhisk-catalog)
 * `WSK_CLI` - the directory where the [`wsk` command line tool](https://github.com/apache/incubator-openwhisk-cli) can be found
 * `DOCKER_IMAGE_PREFIX` - the prefix of the docker images used for actions. If you are building and testing checkouts of runtimes locally, then consider setting this to `whisk`.


### PR DESCRIPTION
This PR fixes an issue resulting in deleting local changes, when `OPENWHISK_PROJECT_HOME` is set.

## Expected behavior
Keep the local openwhisk changes.

## Actual behavior
The local changes to openwhisk are deleted.
