### PR TITLE
Pre-create minio directory

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -212,6 +212,7 @@ setup:
 	rm -rf ~/tmp/openwhisk/api-gateway-config
 	mkdir -p ~/tmp/openwhisk/api-gateway-config/api-gateway
 	mkdir -p ~/tmp/openwhisk/api-gateway-ssl
+	mkdir -p ~/tmp/openwhisk/minio
 	cp -r ./apigateway/* ~/tmp/openwhisk/api-gateway-config/api-gateway/
 	cp -r ./apigateway/rclone ~/tmp/openwhisk
 	$(shell cat ~/tmp/openwhisk/local.env) docker-compose --project-name openwhisk up minio 2>&1 > ~/tmp/openwhisk/setup.log &


### PR DESCRIPTION
On Travis CI a number of directories get created by rclone in docker-compose and this leads to issues as those directories get set to root and are then not able to be edited. https://github.com/apache/incubator-openwhisk-devtools/pull/178 fixed the `api-gateway-ssl`. This fixes the `minio` file.

Travis CI Logs: https://travis-ci.org/apache/incubator-openwhisk-devtools/jobs/459983182#L617-L625
```
ls -l ~/tmp/openwhisk
/home/travis/tmp/openwhisk:
total 24
drwxrwxr-x 3 travis travis 4096 Nov 26 22:26 api-gateway-config
drwxr-xr-x 2 root   root   4096 Nov 26 22:27 api-gateway-ssl
-rw-rw-r-- 1 travis travis  109 Nov 26 22:26 local.env
drwxr-xr-x 4 root   root   4096 Nov 26 22:27 minio
drwxrwxr-x 2 travis travis 4096 Nov 26 22:26 rclone
-rw-rw-r-- 1 travis travis 1904 Nov 26 22:27 setup.log
```

It's not just a Travis CI problem. Some people have been experiencing issues due to the minio directory being created by rclone: https://github.com/apache/incubator-openwhisk-devtools/issues/116#issuecomment-442045047

This PR fixes that.