### PR TITLE
Fix support for `wsk sdk install docker`

### DIFF
--- a/docker-compose/apigateway/generated-conf.d/whisk-docker-compose.conf
+++ b/docker-compose/apigateway/generated-conf.d/whisk-docker-compose.conf
@@ -38,4 +38,8 @@ server {
     proxy_read_timeout 70s; # 60+10 additional seconds to allow controller to terminate request
   }
 
+  location /blackbox.tar.gz {
+    return 301 https://github.com/apache/incubator-openwhisk-runtime-docker/releases/download/sdk%400.1.0/blackbox-0.1.0.tar.gz;
+  }
+
 }


### PR DESCRIPTION
* Add `/blackbox.tar.gz` location to apigateway config