### PR TITLE
Enable user metrics

### DIFF
--- a/docker-compose/docker-whisk-controller.env
+++ b/docker-compose/docker-whisk-controller.env
@@ -39,6 +39,8 @@ CONFIG_kamon_statsd_port=8125
 CONFIG_whisk_loadbalancer_invokerUserMemory=1024m
 CONFIG_whisk_containerPool_userMemory=1024m
 
+CONFIG_whisk_userEvents_enabled=true
+
 CONTROLLER_BLACKBOXFRACTION=0.10
 CONTROLLER_OPTS=-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.port=1098 -Xdebug -Xrunjdwp:transport=dt_socket,address=9222,server=y,suspend=n
 CONTROLLER_HA=False


### PR DESCRIPTION
User metrics can be enabled by adding `CONFIG_whisk_userEvents_enabled=true` as part of the invoker configuration. 

More on what exactly is being tracked by activating this feature, can be found in the [openwhisk documentation](https://github.com/apache/incubator-openwhisk/blob/996d00190553a42b451167200885521ee0dc491b/docs/metrics.md#user-specific-metrics).