### PR TITLE
Redirect controller logs to correct location

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -40,7 +40,7 @@ services:
   # WHISK CONTROLLER
   controller:
     image: ${DOCKER_IMAGE_PREFIX:-openwhisk}/controller
-    command: /bin/sh -c "exec /init.sh 0 >> /home/owuser/controller-local_logs.log 2>&1"
+    command: /bin/sh -c "exec /init.sh 0 >> /logs/controller-local_logs.log 2>&1"
     links:
       - db:db.docker
       - kafka:kafka.docker


### PR DESCRIPTION
In the docker-compose file we are redirecting files to the wrong
location, therefore they are not available outside the Docker container.