### PR TITLE
Update apache:couchdb Docker image to 2.3

### DIFF
--- a/docker-compose/docker-compose-lean.yml
+++ b/docker-compose/docker-compose-lean.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
   db:
-    image: apache/couchdb:2.1
+    image: apache/couchdb:2.3
     ports:
       - "5984:5984"
     environment:


### PR DESCRIPTION
Adding what happened in [#257](https://github.com/apache/incubator-openwhisk-devtools/commit/f39ad575d6dc31465b5d26c796b45143126270a9) for docker-compose-lean.yml (currently lean setup is failing)