### PR TITLE
Fixed Kafka provider setup

### DIFF
--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -450,6 +450,8 @@ setup-providers:
 	printf "ENDPOINT_AUTH=`cat $(realpath $(OPENWHISK_PROJECT_HOME))/ansible/files/auth.whisk.system`\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 	printf "HOST_MACHINE=$(DOCKER_HOST_IP)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 	printf "DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
+	printf "DOCKER_IMAGE_PREFIX"="openwhisk\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
+	printf "DOCKER_IMAGE_TAG"="nightly\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 
 .PHONY: $(addprefix download-package-,$(PACKAGES))
 $(addprefix download-package-,$(PACKAGES)):

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -450,7 +450,7 @@ setup-providers:
 	printf "ENDPOINT_AUTH=`cat $(realpath $(OPENWHISK_PROJECT_HOME))/ansible/files/auth.whisk.system`\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 	printf "HOST_MACHINE=$(DOCKER_HOST_IP)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 	printf "DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
-	printf "DOCKER_IMAGE_PREFIX"="openwhisk\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
+	printf "DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 	printf "DOCKER_IMAGE_TAG"="nightly\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 
 .PHONY: $(addprefix download-package-,$(PACKAGES))

--- a/docker-compose/Makefile
+++ b/docker-compose/Makefile
@@ -451,7 +451,7 @@ setup-providers:
 	printf "HOST_MACHINE=$(DOCKER_HOST_IP)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 	printf "DOCKER_COMPOSE_HOST=$(DOCKER_HOST_IP)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 	printf "DOCKER_IMAGE_PREFIX=$(DOCKER_IMAGE_PREFIX)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
-	printf "DOCKER_IMAGE_TAG"="nightly\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
+	printf "DOCKER_IMAGE_TAG=$(DOCKER_IMAGE_TAG)\n" >> $(TMP_HOME)/tmp/openwhisk/providers.env
 
 .PHONY: $(addprefix download-package-,$(PACKAGES))
 $(addprefix download-package-,$(PACKAGES)):


### PR DESCRIPTION
Fixes the setup of the Kafka provider. Currently, it gives an error because docker-compose tries to pull the docker container with the "latest" tag instead of the "nightly" one. 

The changes in the pull request fix this issue.